### PR TITLE
Fix typo in GetLastRnSaveData->LoadDataFromSlot

### DIFF
--- a/Utility/SaveManager.cs
+++ b/Utility/SaveManager.cs
@@ -177,7 +177,7 @@ namespace RelentlessNight
             {
                 if (saveSlot.m_SaveSlotName.StartsWith(rnSavePrefix))
                 {
-                    return SaveGameSlots.LoadDataFromSlot(saveSlot.m_SaveSlotName, "Relentless Night");
+                    return SaveGameSlots.LoadDataFromSlot(saveSlot.m_SaveSlotName, "RelentlessNight");
                 }
             }
             return null;


### PR DESCRIPTION
Not setup to test TLD <=2.02 but this typo appears to have been introduced in RH V4.50, seems fairly obviously a mistake.

Causing mod settings loading inconsistency, reported by @SmokyRawSauce on discord.